### PR TITLE
Use grid file

### DIFF
--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -23,25 +23,36 @@ function runModelProcess(baseArgs: string[]): IPty {
     'model',
     'trained_model.pkl'
   );
+  // TODO: Display a warning to the user if the grid file is missing.
+  const gridFile = path.join(modelsRoot, 'biomonitoring_stations.csv');
 
   if (isDev) {
     return spawn(
       'venv/bin/python3',
-      ['main.py', '--model', modelPath, ...baseArgs],
+      ['main.py', '--model', modelPath, '--grid_file', gridFile, ...baseArgs],
       { cwd: 'models/runner' }
     );
   }
   if (isWin) {
     return spawn(
       'main.exe',
-      ['--model', modelPath, ...baseArgs, '--pytorch_num_workers=0'],
+      [
+        '--model',
+        modelPath,
+        '--grid_file',
+        gridFile,
+        ...baseArgs,
+        '--pytorch_num_workers=0'
+      ],
       { cwd: 'models/win_runner/main' }
     );
   }
   if (isLinux) {
-    return spawn('main', ['--model', modelPath, ...baseArgs], {
-      cwd: 'models/linux_runner/main'
-    });
+    return spawn(
+      'main',
+      ['--model', modelPath, '--grid_file', gridFile, ...baseArgs],
+      { cwd: 'models/linux_runner/main' }
+    );
   }
   throw new Error(
     `Unsupported operating system for running models: ${process.platform}`

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -54,7 +54,7 @@ type Props = {
 };
 
 function getObservationCoordinates(row: Observation): [number, number] {
-  return [row.exif_gps_long, row.exif_gps_lat];
+  return [row.coordinates_long, row.coordinates_lat];
 }
 
 function makeLocationFeature(observations: Observation[]) {

--- a/app/components/ObservationsTable.tsx
+++ b/app/components/ObservationsTable.tsx
@@ -43,9 +43,9 @@ export default function ObservationsTable(props: Props) {
         cellRenderer={(rowIndex: number) => (
           <Cell>
             Lat:
-            {observations[rowIndex].exif_gps_lat}
+            {observations[rowIndex].coordinates_lat}
             Lon:
-            {observations[rowIndex].exif_gps_long}
+            {observations[rowIndex].coordinates_long}
           </Cell>
         )}
       />

--- a/app/constants/ObservationsData.ts
+++ b/app/constants/ObservationsData.ts
@@ -5,8 +5,8 @@ type Observation = {
   station: string;
   check: string;
   camera: string;
-  exif_gps_lat: number;
-  exif_gps_long: number;
+  coordinates_lat: number;
+  coordinates_long: number;
 };
 
 type ObservationsData = {

--- a/models/runner/functions.py
+++ b/models/runner/functions.py
@@ -148,15 +148,16 @@ def add_station_coords(df, grid_file):
 
 def add_output_coords(df):
     """Add output coordinates determined on best-effort basis"""
-    def prefer_exif(row):
+    def f(row):
         # We assume that longitude is present iff latiitude is present.
-        if pd.notnull(row["exif_gps_long"]):
-            return row[["exif_gps_long", "exif_gps_lat"]]
+        if pd.notnull(row["exif_gps_long"]):  # Prefer Exif.
+            row["coordinates_long"] = row["exif_gps_long"]
+            row["coordinates_lat"] = row["exif_gps_lat"]
         else:
-            return row[["grid_file_long", "grid_file_lat"]]
-    df = df.copy()
-    df[["coordinates_long", "coordinates_lat"]] = df.apply(prefer_exif, axis=1)
-    return df
+            row["coordinates_long"] = row["grid_file_long"]
+            row["coordinates_lat"] = row["grid_file_lat"]
+        return row
+    return df.apply(f, axis=1)
 
 def order_df(df,var):
     """ make the var list of columns as the first columns, keep rest at the end in df """

--- a/models/runner/functions.py
+++ b/models/runner/functions.py
@@ -149,13 +149,15 @@ def add_station_coords(df, grid_file):
 def add_output_coords(df):
     """Add output coordinates determined on best-effort basis"""
     def f(row):
-        # We assume that longitude is present iff latiitude is present.
-        if pd.notnull(row["exif_gps_long"]):  # Prefer Exif.
-            row["coordinates_long"] = row["exif_gps_long"]
-            row["coordinates_lat"] = row["exif_gps_lat"]
+        # Prefer Exif.
+        if pd.notnull(row["exif_gps_long"]) and pd.notnull(row["exif_gps_lat"]):
+            long, lat = row["exif_gps_long"], row["exif_gps_lat"]
+        elif pd.notnull(row["grid_file_long"]) and pd.notnull(row["grid_file_lat"]):
+            long, lat = row["grid_file_long"], row["grid_file_lat"]
         else:
-            row["coordinates_long"] = row["grid_file_long"]
-            row["coordinates_lat"] = row["grid_file_lat"]
+            long, lat = None, None
+        row["coordinates_long"] = long
+        row["coordinates_lat"] = lat
         return row
     return df.apply(f, axis=1)
 

--- a/models/runner/main.py
+++ b/models/runner/main.py
@@ -28,6 +28,11 @@ def main():
         help="Path to the output .csv file with results",
     )
     parser.add_argument(
+        "--grid_file",
+        metavar="/path/to/stations.csv",
+        help="Path to a .csv file with the coordinates of monitoring stations",
+    )
+    parser.add_argument(
         "--keep_scores",
         default = False,
         action = "store_true",
@@ -47,7 +52,7 @@ def main():
     )
 
     args = parser.parse_args()
-    infer_to_csv(args.model, args.input_folder, args.output, args.keep_scores, args.overwrite, args.pytorch_num_workers)
+    infer_to_csv(args)
 
 if (__name__ == "__main__"):
     main()


### PR DESCRIPTION
This PR mostly resolves #63. The classifier script now outputs additional columns with station coordinates taken from the grid file. The explorer uses the new columns for display.

A better warning should be displayed to the user if the grid file doesn't exist. Right now the user will see `FileNotFoundError` exception streamed from the classifier script.