### PR TITLE
Use Node's built-in module to spawn classifier

### DIFF
--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Button } from '@blueprintjs/core';
-import { spawn, IPty } from 'node-pty';
 import { useTranslation } from 'react-i18next';
 import path from 'path';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
 
 import PythonLogViewer from './PythonLogViewer';
 
 type changeLogMessageType = (newChangeLogMessage: string) => {};
 type changePathChoiceType = (newPath: string) => {};
 
-function runModelProcess(baseArgs: string[]): IPty {
+function runModelProcess(baseArgs: string[]): ChildProcessWithoutNullStreams {
   const isDev = process.env.NODE_ENV === 'development';
   const isWin = !isDev && process.platform === 'win32';
   const isLinux = !isDev && process.platform === 'linux';
@@ -23,10 +23,12 @@ function runModelProcess(baseArgs: string[]): IPty {
     program = path.join(workdir, 'venv', 'bin', 'python3');
     args.push('main.py');
   } else if (isWin) {
-    workdir = path.join(root, 'win_runner', 'main');
+    workdir = path.join(root, 'runner_win', 'main');
     program = path.join(workdir, 'main.exe');
+    // TODO: Determine a suitable number of workers in the classifier script.
+    args.push('--pytorch_num_workers=0');
   } else if (isLinux) {
-    workdir = path.join(root, 'linux_runner', 'main');
+    workdir = path.join(root, 'runner_linux', 'main');
     program = path.join(workdir, 'main');
   } else {
     throw new Error(
@@ -56,16 +58,20 @@ const computePredictions = (
     '--overwrite'
   ];
 
-  const pyProcess = runModelProcess(args);
-
-  pyProcess.on('data', data => {
-    // eslint-disable-next-line no-console
-    changeLogMessage(data);
+  // TODO: Fix and simplify logging:
+  //   * Progress bar is not properly displayed in the output (#89).
+  //   * Is `changeLogMessageType` necessary?
+  //   * Are Redux actions appropriate for this use case?
+  const process = runModelProcess(args);
+  process.stdout.on('data', data => {
+    changeLogMessage(`${data}`);
   });
-
-  pyProcess.on('exit', exitCode => {
+  process.stderr.on('data', data => {
+    changeLogMessage(`${data}`);
+  });
+  process.on('exit', exitCode => {
     // eslint-disable-next-line no-console
-    console.log(`Exiting with code ${exitCode}`);
+    console.log(`Classifier exited with code ${exitCode}`);
   });
 };
 

--- a/app/components/PythonLogViewer.tsx
+++ b/app/components/PythonLogViewer.tsx
@@ -12,8 +12,9 @@ export default function PythonLogViewer(props: Props) {
 
   return (
     <Card interactive={false} elevation={Elevation.TWO}>
-      <H5>{t('Prediction progress')}</H5>
-      <p>{logMessage}</p>
+      <H5>{t('Classifier output')}</H5>
+      {/* Code block retains newlines and is more appropriate for terminal output. */}
+      <code>{logMessage}</code>
     </Card>
   );
 }

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,6 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@types/mapbox-gl": "^1.10.2",
-    "mapbox-gl": "^1.10.2",
-    "node-pty": "^0.9.0"
+    "mapbox-gl": "^1.10.2"
   }
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -158,18 +158,6 @@ murmurhash-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
   integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
 
-nan@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
-  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
-
-node-pty@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.9.0.tgz#8f9bcc0d1c5b970a3184ffd533d862c7eb6590a6"
-  integrity sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==
-  dependencies:
-    nan "^2.14.0"
-
 pbf@^3.0.5, pbf@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"


### PR DESCRIPTION
Using `node-pty` module to spawn the classifier process didn't work under Windows (#88). This PR changes the code to use Node's built-in module [`child_process`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) instead. With this PR, a progress bar is no longer shown classifier output panel - only the initial messages and the final result are visible. Issue #93 tracks the reimplementation of that feature.

#### Testing
To test this PR, please:
* Install the app on Windows (use `yarn package-win` to build an installer).
* Unpack the models (build with PR #92!) into the `%USERPROFILE%\AppData\Local\Programs\mbaza-ai` directory. 
* Use the "Detect animals" panel to run the classifier script.
* Check that a CSV file with results is generated once an "Inference complete" message appears.