### PR TITLE
Don't show classifier stderr output in the app

### DIFF
--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -67,7 +67,8 @@ const computePredictions = (
     changeLogMessage(`${data}`);
   });
   process.stderr.on('data', data => {
-    changeLogMessage(`${data}`);
+    // eslint-disable-next-line no-console
+    console.log(`classifier stderr: ${data}`);
   });
   process.on('exit', exitCode => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
The stderr output of the classifier script was way too noisy to be of any use to the user. With this PR it will be redirected it to the console (it still might be useful for debugging).