### PR TITLE
Update the windows installer to be interactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
       ],
       "category": "Development"
     },
+    "nsis": {
+      "runAfterFinish": false,
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
+    },
     "directories": {
       "buildResources": "resources",
       "output": "release"
@@ -127,6 +132,11 @@
       "name": "Wojciech Dziwulski",
       "email": "wojciech.dziwulski@gmail.com",
       "url": "https://github.com/wojdziw"
+    },
+    {
+      "name": "Kamil Żyła",
+      "email": "kamil@appsilon.com",
+      "url": "https://github.com/kamilzyla"
     }
   ],
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
This helps in #103, but doesn't resolve it fully - making the installer interactive the user knows where the app is installed. Non-interactive installer is a bit surprising.

I wasn't able to find how to exactly customize the installer to display a message, but even without a message i think this is helpful.
