### PR TITLE
Classify warnings

### DIFF
--- a/app/actions/logMessage.ts
+++ b/app/actions/logMessage.ts
@@ -5,7 +5,7 @@ export interface ChangeLogMessageAction {
   newLogMessage: string | null;
 }
 
-export function changeLogMessage(newLogMessage: string) {
+export function changeLogMessage(newLogMessage: string | null) {
   return {
     type: CHANGE_LOG_MESSAGE,
     newLogMessage

--- a/app/actions/logMessage.ts
+++ b/app/actions/logMessage.ts
@@ -2,7 +2,7 @@ export const CHANGE_LOG_MESSAGE = 'CHANGE_LOG_MESSAGE';
 
 export interface ChangeLogMessageAction {
   type: typeof CHANGE_LOG_MESSAGE;
-  newLogMessage: string;
+  newLogMessage: string | null;
 }
 
 export function changeLogMessage(newLogMessage: string) {

--- a/app/assets/translations.json
+++ b/app/assets/translations.json
@@ -21,15 +21,20 @@
         }
       },
       "classify": {
+        "title": "Detect animals",
         "chooseInput": "Choose directory with photos",
         "chooseOutput": "Choose where to save the classification results",
         "chooseModel": "Select AI model to use:",
         "find": "Find animals!",
         "output": "Classifier output",
         "inProgress": "Please wait. Animals detection in progress. This may take a long time.",
-        "modelExecutableNotFound": "Could not find the model executable. Please make sure you unpacked the models in the correct directory. It should be in ${program}.",
-        "modelWeightsNotFound": "Could not find the model weights file. Please make sure you unpacked the models in the correct directory. Model weights should be in ${modelWeightsPath}.",
-        "biomonitoringStationsFileNotFound": "Could not find the biomonitoring stations locations file. Locations will not be assigned based on station numbers. Locations will be missing unless they are present in EXIF data in images. The file should be in ${gridFilePath}."
+        "modelExecutableNotFound": "Could not find the model executable. Please make sure you unpacked the models in the correct directory. It should be in {{program}}.",
+        "modelWeightsNotFound": "Could not find the model weights file. Please make sure you unpacked the models in the correct directory. Model weights should be in {{modelWeightsPath}}.",
+        "biomonitoringStationsFileNotFound": "Could not find the biomonitoring stations locations file. Locations will not be assigned based on station numbers. Locations will be missing unless they are present in EXIF data in images. The file should be in {{gridFilePath}}.",
+        "modelsDirectoryMissing": {
+          "title": "Models directory not found",
+          "description": "You need to obtain a zip file containing the AI models and unzip it in the program's main directory. Please make sure that you have a {{rootModelsDirectory}} directory containing the models files."
+        }
       },
       "explore": {
         "chooseFile": "Choose results file to analyze",

--- a/app/assets/translations.json
+++ b/app/assets/translations.json
@@ -34,7 +34,9 @@
         "modelsDirectoryMissing": {
           "title": "Models directory not found",
           "description": "You need to obtain a zip file containing the AI models and unzip it in the program's main directory. Please make sure that you have a {{rootModelsDirectory}} directory containing the models files."
-        }
+        },
+        "success": "Animals detection completed.",
+        "failure": "Animals detection failed."
       },
       "explore": {
         "chooseFile": "Choose results file to analyze",

--- a/app/assets/translations.json
+++ b/app/assets/translations.json
@@ -26,7 +26,10 @@
         "chooseModel": "Select AI model to use:",
         "find": "Find animals!",
         "output": "Classifier output",
-        "inProgress": "Please wait. Animals detection in progress. This may take a long time."
+        "inProgress": "Please wait. Animals detection in progress. This may take a long time.",
+        "modelExecutableNotFound": "Could not find the model executable. Please make sure you unpacked the models in the correct directory. It should be in ${program}.",
+        "modelWeightsNotFound": "Could not find the model weights file. Please make sure you unpacked the models in the correct directory. Model weights should be in ${modelWeightsPath}.",
+        "biomonitoringStationsFileNotFound": "Could not find the biomonitoring stations locations file. Locations will not be assigned based on station numbers. Locations will be missing unless they are present in EXIF data in images. The file should be in ${gridFilePath}."
       },
       "explore": {
         "chooseFile": "Choose results file to analyze",

--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -1,5 +1,15 @@
 import React, { useState } from 'react';
-import { Button, Intent, Radio, RadioGroup, Toaster } from '@blueprintjs/core';
+import {
+  Button,
+  Card,
+  Elevation,
+  H1,
+  Intent,
+  NonIdealState,
+  Radio,
+  RadioGroup,
+  Toaster
+} from '@blueprintjs/core';
 import { useTranslation } from 'react-i18next';
 import path from 'path';
 import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
@@ -66,13 +76,13 @@ function runModelProcess(
   }
 
   if (!fs.existsSync(program)) {
-    displayErrorToast(t('modelExecutableNotFound', { program }));
+    displayErrorToast(t('classify.modelExecutableNotFound', { program }));
     return null;
   }
 
   if (!fs.existsSync(gridFilePath)) {
     displayWarningToast(
-      t('biomonitoringStationsFileNotFound', { gridFilePath })
+      t('classify.biomonitoringStationsFileNotFound', { gridFilePath })
     );
   }
 
@@ -106,7 +116,7 @@ const computePredictions = (
   ];
 
   if (!fs.existsSync(modelWeightsPath)) {
-    displayErrorToast(t('modelWeightsNotFound', { modelWeightsPath }));
+    displayErrorToast(t('classify.modelWeightsNotFound', { modelWeightsPath }));
     return;
   }
 
@@ -203,8 +213,22 @@ export default function Classifier(props: Props) {
     { label: 'Serengeti', value: 'serengeti' }
   ];
   const [modelName, setModelName] = useState<string>(models[0].value);
+  const rootModelsDirectoryExists = fs.existsSync(rootModelsDirectory);
 
-  return (
+  const missingModelsDirectoryView = (
+    <NonIdealState
+      icon="search"
+      title={t('classify.modelsDirectoryMissing.title')}
+    >
+      <p>
+        {t('classify.modelsDirectoryMissing.description', {
+          rootModelsDirectory
+        })}
+      </p>
+    </NonIdealState>
+  );
+
+  const classifierFormView = (
     <div style={{ padding: '30px 30px', width: '60vw' }}>
       <div className="bp3-input-group" style={{ marginBottom: '10px' }}>
         <input
@@ -276,6 +300,21 @@ export default function Classifier(props: Props) {
       />
 
       <PythonLogViewer logMessage={logMessage} isRunning={isRunning} />
+    </div>
+  );
+
+  return (
+    <div style={{ flex: 1 }}>
+      <div style={{ display: 'flex' }}>
+        <div style={{ flex: 1, padding: '20px' }}>
+          <Card elevation={Elevation.TWO}>
+            <H1>{t('classify.title')}</H1>
+            {rootModelsDirectoryExists
+              ? classifierFormView
+              : missingModelsDirectoryView}
+          </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -116,10 +116,10 @@ const computePredictions = (
     '--overwrite'
   ];
 
-  // if (!fs.existsSync(modelWeightsPath)) {
-  //   displayErrorToast(t('classify.modelWeightsNotFound', { modelWeightsPath }));
-  //   return;
-  // }
+  if (!fs.existsSync(modelWeightsPath)) {
+    displayErrorToast(t('classify.modelWeightsNotFound', { modelWeightsPath }));
+    return;
+  }
 
   // TODO: Fix and simplify logging:
   //   * Progress bar is not properly displayed in the output (#89).

--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -303,7 +303,7 @@ export default function Classifier(props: Props) {
             t
           );
         }}
-        disabled={isRunning}
+        disabled={isRunning || directoryChoice === '' || savePath === ''}
         style={{ marginBottom: '10px', backgroundColor: '#fff' }}
       />
 

--- a/app/components/PythonLogViewer.tsx
+++ b/app/components/PythonLogViewer.tsx
@@ -1,27 +1,45 @@
 import React from 'react';
-import { Card, Elevation, H5, H6, Spinner } from '@blueprintjs/core';
+import {
+  Callout,
+  Card,
+  Elevation,
+  H5,
+  H6,
+  Intent,
+  Pre,
+  Spinner
+} from '@blueprintjs/core';
 import { useTranslation } from 'react-i18next';
 
 type Props = {
   logMessage: string;
   isRunning: boolean;
+  exitCode: number | null | undefined;
 };
 
 export default function PythonLogViewer(props: Props) {
-  const { logMessage, isRunning } = props;
+  const { logMessage, isRunning, exitCode } = props;
   const { t } = useTranslation();
+
+  const resultView =
+    exitCode === 0 ? (
+      <Callout intent={Intent.SUCCESS} title={t('classify.success')} />
+    ) : (
+      <Callout intent={Intent.DANGER} title={t('classify.failure')} />
+    );
 
   return (
     <Card interactive={false} elevation={Elevation.TWO}>
       <H5>{t('classify.output')}</H5>
       {/* Code block retains newlines and is more appropriate for terminal output. */}
-      <code>{logMessage}</code>
+      <Pre style={{ whiteSpace: 'pre-wrap' }}>{logMessage}</Pre>
       {isRunning ? (
         <div style={{ marginTop: '20px', textAlign: 'center' }}>
           <Spinner />
           <H6 style={{ marginTop: '20px' }}>{t('classify.inProgress')}</H6>
         </div>
       ) : null}
+      {exitCode !== undefined ? resultView : null}
     </Card>
   );
 }

--- a/app/components/PythonLogViewer.tsx
+++ b/app/components/PythonLogViewer.tsx
@@ -31,7 +31,6 @@ export default function PythonLogViewer(props: Props) {
   return (
     <Card interactive={false} elevation={Elevation.TWO}>
       <H5>{t('classify.output')}</H5>
-      {/* Code block retains newlines and is more appropriate for terminal output. */}
       <Pre style={{ whiteSpace: 'pre-wrap' }}>{logMessage}</Pre>
       {isRunning ? (
         <div style={{ marginTop: '20px', textAlign: 'center' }}>

--- a/app/reducers/logMessage.ts
+++ b/app/reducers/logMessage.ts
@@ -6,8 +6,14 @@ import {
 export default function logMessage(state = '', action: ChangeLogMessageAction) {
   switch (action.type) {
     case CHANGE_LOG_MESSAGE:
+      if (action.newLogMessage == null) {
+        return '';
+      }
+      if (state !== '') {
+        return `${state}\n${action.newLogMessage}`;
+      }
       return action.newLogMessage;
     default:
-      return state;
+      return '';
   }
 }

--- a/models/runner/main.py
+++ b/models/runner/main.py
@@ -53,6 +53,7 @@ def main():
 
     args = parser.parse_args()
     infer_to_csv(args)
+    exit(0)
 
 if (__name__ == "__main__"):
     main()


### PR DESCRIPTION
Closes #103 

## Description
This PR adds a bunch of improvements to the classification flow:
- display warnings when models files are missing
- when the entire directory is missing, display a nice instruction
- stream all stdout without hiding previous lines
- show the stderr in case it appears - this will be useful for debugging, even if happens on the client machine
- only enable the run button when classification isn't running and all fields are filled
- show success/failed box after process exits

overall i think this makes up to a much better experience