### PR TITLE
Add functionality for camera trap video classification

### DIFF
--- a/app/assets/translations.json
+++ b/app/assets/translations.json
@@ -13,7 +13,7 @@
       "home": {
         "welcome": {
           "title": "Welcome to Mbaza AI!",
-          "message": "<h4>The first offline AI wildlife explorer</h4> <p>Mbaza AI is a desktop application that allows bioconservation researchers to classify camera trap animal images and analyze the results.</p> <p>It is powered by AI models capable of recognizing over 30 animal species in photos.</p> <p>To use the application, first go to Classify and run AI on your photos dataset. Then you can go to Explore and analyze the results.</p>"
+          "message": "A multi-platform, offline application for classifying camera trap images </h4> <p>Mbaza AI allows biodiversity conservation researchers to automatically identify species in camera trap images and analyze the results. </p> <p> It is powered by high performance AI models and currently recognizes more than 30 species of Central African mammals and birds.</p> <p> To use the application, first go to Classify and run the AI on your photo dataset, then click Explore to view and analyze the results.</p>"
         },
         "warning": {
           "title": "This is an early development version",
@@ -23,25 +23,25 @@
       "classify": {
         "title": "Detect animals",
         "chooseInput": "Choose directory with photos",
-        "chooseOutput": "Choose where to save the classification results",
+        "chooseOutput": "Choose directory to save classification results",
         "chooseModel": "Select AI model to use:",
         "find": "Find animals!",
         "output": "Classifier output",
-        "inProgress": "Please wait. Animals detection in progress. This may take a long time.",
+        "inProgress": "Please wait. Animal detection in progress. This may take a long time.",
         "modelExecutableNotFound": "Could not find the model executable. Please make sure you unpacked the models in the correct directory. It should be in {{program}}.",
         "modelWeightsNotFound": "Could not find the model weights file. Please make sure you unpacked the models in the correct directory. Model weights should be in {{modelWeightsPath}}.",
-        "biomonitoringStationsFileNotFound": "Could not find the biomonitoring stations locations file. Locations will not be assigned based on station numbers. Locations will be missing unless they are present in EXIF data in images. The file should be in {{gridFilePath}}.",
+        "biomonitoringStationsFileNotFound": "Could not find the biomonitoring stations file. Locations will not be assigned based on station numbers. Locations will be missing unless they are present in EXIF data in images. The file should be in {{gridFilePath}}.",
         "modelsDirectoryMissing": {
           "title": "Models directory not found",
           "description": "You need to obtain a zip file containing the AI models and unzip it in the program's main directory. Please make sure that you have a {{rootModelsDirectory}} directory containing the models files."
         },
-        "success": "Animals detection completed.",
-        "failure": "Animals detection failed."
+        "success": "Species classification completed.",
+        "failure": "Species classification failed."
       },
       "explore": {
         "chooseFile": "Choose results file to explore",
         "selectFileDescription": "Please select a CSV file with detection results to analyze them.",
-        "mapHint": "Size of circle corresponds to the number of detected species. Click on a station to see details.",
+        "mapHint": "Size of circle corresponds to the number of detected species (species richness). Click on a station to see details.",
         "plotHint": "To save the plot to disk, hover on the plot and use the button with a camera icon",
         "changeFile": "Change data",
         "mainView": "Main Information",
@@ -50,17 +50,17 @@
         "animalsCount": "Images with animals",
         "speciesCount": "Species found",
         "rareCount": "Rare species found",
-        "byAnimal": "By animal",
+        "byAnimal": "By species",
         "byStation": "By station",
-        "byCamera": "By camera",
+        "byCamera": "By camera ID",
         "byCheck": "By check",
-        "plotTitle": "Animals count over time ({{windowLengthInDays}}-day intervals)",
+        "plotTitle": "Image count over time ({{windowLengthInDays}}-day intervals)",
         "inspect": {
           "station": "Station {{id}}",
           "observations": "{{count}} observations",
           "species": "{{count}} species",
-          "header": "Observations in station {{station}}",
-          "photoHeader": "{{species}} probably seen at {{date}}",
+          "header": "Observations by station {{station}}",
+          "photoHeader": "{{species}} {{date}}",
           "prediction": "Prediction",
           "probability": "Probability",
           "camera": "Camera",
@@ -70,6 +70,71 @@
     }
   },
   "fr": {
-    "translation": {}
+    "translation": {
+      "topbar": {
+        "title": "IA pour la découverte des espèces",
+        "projects": "Projets"
+      },
+      "sidebar": {
+        "home": "Accueil",
+        "classify": "Détectez les animaux",
+        "explore": "Explorez les résultats"
+      },
+      "home": {
+        "welcome": {
+          "title": "Bienvenue à Mbaza AI !",
+          "message": "<h4>Un logiciel multi-plateforme et hors ligne pour l'analyze d'images des pièges caméra </h4> <p>Mbaza IA est une application pour les chercheurs de conservation de biodiversité d'identifier automatiquement les espèces dans les images des pièges caméra et d'analyser les résultats.</p> <p>Elle est alimentée par modèles IA de haute performance capables de reconnaître plus de 30 mammifères et oiseaux des forêts d'Afrique centrale.</p> <p>Pour utiliser l'application, allez d'abord dans Detectez et exécutez l'IA sur votre ensemble de données de photos. Cliquez ensuite sur Explorez pour visualiser et analyser les résultats.</p>" },
+        "warning": {
+          "title": "Il s'agit d'une première version de développement",
+          "message":"<p>Vous utilisez une toute première version de Mbaza IA.</p> <p>Cette application est en cours de développement actif et fournit seulement les fonctionnalités de base. Tout commentaire concernant les fonctionnalités et le comportement de l'application est bienvenu - veuillez nous envoyer un courriel à ai4good@appsilon.com.</p>"
+        }
+      },
+      "classify": {
+        "title": "Détectez les animaux",
+        "chooseInput": "Choisissez un dossier avec des photos",
+        "chooseOutput": "Choisissez un dossier pour sauvegarder les résultats de la classification",
+        "chooseModel": "Sélectionnez le modèle d'IA à utiliser :",
+        "find": "Trouver des animaux !",
+        "output": "Sortie du classifieur",
+        "inProgress": "Veuillez patienter. Détection d'animaux en cours. Cela peut prendre beaucoup de temps.",
+        "modelExecutableNotFound": "Le modèle d'exécutable n'a pas été trouver. Veuillez vous assurer que vous avez décompressé les modèles dans le bon dossier. Il devrait être dans {{program}}.",
+        "modelWeightsNotFound": "Le fichier des poids modèles n'a pas été trouvé. Veuillez vous assurer que vous avez décompressé les modèles dans le bon dossier. Les poids des modèles doivent être dans le dossier {{modelWeightsPath}}.",
+        "biomonitoringStationsFileNotFound": "Le fichier des stations de biomonitoring n'a pas été trouvé. Les stations ne seront pas attribuées en fonction de leur numéro. Les localisations seront manquantes à moins qu'elles ne soient présentes dans les données EXIF des images. Le fichier doit être dans {{gridFilePath}}.",
+        "modelsDirectoryMissing": {
+          "title": "Le répertoire des modèles n'a pas été trouvé",
+          "description": "Vous devez obtenir un fichier zip contenant les modèles d'IA et le décompresser dans le dossier principal du programme. Veuillez vous assurer que vous disposez d'un répertoire {{rootModelsDirectory}} contenant les fichiers de modèles."
+        },
+        "success": "La détection des animaux est terminée.",
+        "failure": "La détection des animaux a échoué."
+      },
+      "explore": {
+        "chooseFile": "Choisissez le fichier de résultats à explorer",
+        "selectFileDescription": "Veuillez sélectionnez un fichier CSV avec les résultats de la détection pour les analyser.",
+        "mapHint": "La taille du cercle correspond au nombre d'espèces détectées. Cliquez sur une station pour voir les détails.",
+        "plotHint": "Pour enregistrer le graphique sur le disque, passez le curseur sur le graphique et utilisez le bouton avec l'icône d'un appareil photo.",
+        "changeFile": "Modifier les données",
+        "mainView": "Informations principales",
+        "tableView": "Tableau des observations",
+        "imagesCount": "Images classifiées",
+        "animalsCount": "Images avec des animaux",
+        "speciesCount": "Espèces trouvées",
+        "rareCount": "Espèces rares trouvées",
+        "byAnimal": "Par espèce",
+        "byStation": "Par station",
+        "byCamera": "Par ID d'appareil photo",
+        "byCheck": "Par check",
+        "plotTitle": "Comptage des animaux dans le temps ({{windowLengthInDays}}-intervalles de jours)",
+        "inspect": {
+          "station": "Station {{id}}",
+          "observations": "{{count}} observations",
+          "species": "{{count}} espèces",
+          "header": "Observations par station {{station}}",
+          "photoHeader": "{{species}} {{date}}",
+          "prediction": "Prédiction",
+          "probability": "Probabilité",
+          "camera": "ID de l'appareil photo",
+          "check": "Check"
+        }
+      }}
   }
 }

--- a/models/runner/extract_frames.py
+++ b/models/runner/extract_frames.py
@@ -1,0 +1,34 @@
+# This script extracts image frames from camera trap videos
+# It then copies the images to a new directory (replicating original video dir structure)
+# This new image directory can then be classified
+
+# paths for testing
+video_data_folder = '/home/robbie/Documents/MbazaVideoTest/videos/' # user selects video directory
+
+new_image_data_folder = '/home/robbie/Documents/MbazaVideoTest/images/' # user selects empty directory for images
+
+videos = get_videos(video_data_folder)
+
+copy_dir_tree(video_data_folder, new_image_data_folder)
+
+# Loop through videos and extract frames to new image directory
+for videos in videos:
+    
+    vid = cv2.VideoCapture(videos) # read video
+    
+    frameIndex = 0
+    
+    while(True):
+        # Extract images
+        vid.set(cv2.CAP_PROP_POS_MSEC,(frameIndex*5000)) # frame every 5 seconds
+        ret, frame = vid.read()
+        # end of frames
+        if not ret: 
+            break
+        # Saves images
+        name = os.path.dirname(os.path.abspath(videos.replace(video_data_folder, new_image_data_folder))) + '/' + get_filename(videos) + '_' + f"{frameIndex+1:02d}" + '.jpg'
+        print ('Creating...' + name)
+        cv2.imwrite(name, frame)
+    
+        # next frame
+        frameIndex += 1

--- a/models/runner/extract_frames.py
+++ b/models/runner/extract_frames.py
@@ -1,6 +1,7 @@
 # This script extracts image frames from camera trap videos
 # It then copies the images to a new directory (replicating original video dir structure)
 # This new image directory can then be classified
+# Functions are in functions_video.py
 
 # paths for testing
 video_data_folder = '/home/robbie/Documents/MbazaVideoTest/videos/' # user selects video directory

--- a/models/runner/functions_video.py
+++ b/models/runner/functions_video.py
@@ -1,0 +1,230 @@
+# This script loads all images in subfolders of a specified folder and a model.
+# Next it runs inference from the model on the images and saves a csv with image path, classification, possibly toop predictions and scores.
+import warnings
+
+import os
+from datetime import datetime
+
+from pathlib import Path
+
+import pandas as pd
+
+from fastai import *
+from fastai.vision import *
+
+import exifread
+
+warnings.filterwarnings('ignore')
+
+N_TOP_RESULTS = 3
+
+def is_video(filename):
+    return filename.endswith(("avi", "MP4")) # had a problem with lower() so removed
+
+def get_videos(data_folder):
+    videos = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(data_folder):
+            for filename in [f for f in filenames if is_video(f)]:
+                videos.append(os.path.join(dirpath, filename))
+    except Exception as e:
+        print(f"Got exception {e}, double check {data_folder} is a folder")
+    assert videos, "No videos found in the folder"
+    print(f"Found {len(videos)} videos.")
+    return videos
+
+# Re-create directory structure in new image folder
+# TO DO
+
+# Extract video frames and output to new image directories
+def extract_frames(video):
+    index = 0
+    while(True):
+        # Extract images
+        video.set(cv2.CAP_PROP_POS_MSEC,(index*15000)) # frame every 15 seconds
+        ret, frame = video.read()
+        # end of frames
+        if not ret: 
+            break
+    # Saves images
+    name = IMAGEDIR + VIDNAME + '_' + f"{index+1:02d}" + '.jpg'
+    print ('Creating...' + name)
+    cv2.imwrite(name, frame)
+
+    # next frame
+    index += 1
+
+
+def load_model(model, images, pytorch_num_workers, batch_size):
+    model_path = Path(model)
+    print(f"Loading model: {model}.")
+    assert model_path.exists(), f"It seems {model} is not a file"
+    assert model_path.suffix == ".pkl", "The model should end with .pkl"
+    learn = load_learner(model_path.parent, model_path.name, test=images, num_workers=pytorch_num_workers)
+    learn.data.batch_size = batch_size
+    # learn.callback_fns=[]
+    print(f"Model loaded.")
+    return learn
+
+def get_gpu_status(learn):
+    if torch.cuda.device_count() > 0:
+        print("GPU available.")
+        try:
+            learn.model = model.cuda()
+            print("Using GPU for inference.")
+        except:
+            print("Unable to use GPU, using CPU.")
+    else:
+        print("No GPU detected.")
+
+def run_inference(learn):
+    inference_start = datetime.now()
+    print(f"Starting inference. time={inference_start}")
+    preds,y = learn.get_preds(ds_type=DatasetType.Test)
+    inference_stop = datetime.now()
+    print(f"Inference complete. It took {inference_stop - inference_start}.")
+    return preds
+
+def get_predictions(model, images, pytorch_num_workers, batch_size):
+    learn = load_model(model, images, pytorch_num_workers, batch_size)
+    get_gpu_status(learn)
+    preds = run_inference(learn)
+    classes = learn.data.classes
+    preds = pd.DataFrame(
+            np.stack(preds),
+            columns=classes,
+        )
+    return preds, classes
+
+def get_top_preds_and_scores(preds, classes):
+    df_preds = preds.copy()
+    ranks = df_preds.rank(axis=1,method='dense', ascending=False).astype(int)
+
+    for i in range(1, N_TOP_RESULTS + 1):
+        df_preds[f"pred_{i}"] = pd.Series(ranks.where(ranks==i).notnull().values.nonzero()[1]).apply(lambda x: classes[x])
+        df_preds[f"score_{i}"] = df_preds.apply(lambda x: x[x[f"pred_{i}"]], axis=1)
+
+    return df_preds
+
+def parse_path(df):
+    """ extract station, check and cam from path column and store. """
+    pattern = r"Check\s(\d*).*STATION_(\d*).*CAM(\d*).*[\\/](\d{6})[\\/]"
+    result = df.copy()
+    result[["check", "station", "camera", "path_date"]] = result.path.str.extract(pattern)
+    result["station"] = pd.to_numeric(result["station"])
+    result["path_date"] = pd.to_datetime(result["path_date"], format="%m%d%y").map(lambda x: x.date())
+    return result
+
+def read_exif_coords(tags):
+    """Read GPS coordinates from Exif tags and return longitude, latitude tuple"""
+    def get_coord(ref, coord):
+        ref = {"N": 1, "S": -1, "W": -1, "E": 1}[ref.values]
+        degrees, minutes, seconds = (v.num / v.den for v in coord.values)
+        return ref * (degrees + minutes / 60 + seconds / 3600)
+
+    try:
+        long = get_coord(tags["GPS GPSLongitudeRef"], tags["GPS GPSLongitude"])
+        lat = get_coord(tags["GPS GPSLatitudeRef"], tags["GPS GPSLatitude"])
+        return long, lat
+    except KeyError:
+        return None, None
+
+def parse_exif(df):
+    """ extract datetime, gps long and gps lat from exif of images """
+    result = df.copy()
+
+    exif_datetime = []
+    exif_gps_long = []
+    exif_gps_lat = []
+    for path_name in result.path:
+        f = open(path_name, 'rb')
+        tags = exifread.process_file(f)
+        if tags:
+            try:
+                exif_datetime.append(tags["EXIF DateTimeOriginal"].values)
+            except KeyError:
+                exif_datetime.append(None)
+            long, lat = read_exif_coords(tags)
+            exif_gps_long.append(long)
+            exif_gps_lat.append(lat)
+        else:
+            exif_datetime.append(None)
+            exif_gps_long.append(None)
+            exif_gps_lat.append(None)
+    exif_datetime = pd.to_datetime(exif_datetime, format="%Y:%m:%d %H:%M:%S")
+    result["exif_date"] = exif_datetime.map(lambda x: x.date())
+    result["exif_time"] = exif_datetime.map(lambda x: x.time())
+    result["exif_gps_long"] = exif_gps_long
+    result["exif_gps_lat"] = exif_gps_lat
+
+    return result
+
+def add_station_coords(df, grid_file):
+    """Add station coordinates matched from the grid file"""
+    # Grid file column name --> output column name mapping.
+    columns = {
+        "locationID": "station",
+        "Longitude": "grid_file_long",
+        "Latitude": "grid_file_lat",
+    }
+    if grid_file is None:
+        # Use empty data frame - as if the grid file had no stations.
+        stations = pd.DataFrame(columns=columns.values())
+    else:
+        stations = pd.read_csv(grid_file)
+        stations.rename(columns=columns, inplace=True, errors="raise")
+    return pd.merge(df, stations, how="left", on="station")
+
+def add_output_coords(df):
+    """Add output coordinates determined on best-effort basis"""
+    def f(row):
+        # Prefer Exif.
+        if pd.notnull(row["exif_gps_long"]) and pd.notnull(row["exif_gps_lat"]):
+            long, lat = row["exif_gps_long"], row["exif_gps_lat"]
+        elif pd.notnull(row["grid_file_long"]) and pd.notnull(row["grid_file_lat"]):
+            long, lat = row["grid_file_long"], row["grid_file_lat"]
+        else:
+            long, lat = None, None
+        row["coordinates_long"] = long
+        row["coordinates_lat"] = lat
+        return row
+    return df.apply(f, axis=1)
+
+def add_output_date(df):
+    """Add output date determined on best-effort basis"""
+    def f(row):
+        # Prefer date extracted from path.
+        if pd.notnull(row["path_date"]):
+            row["date"] = row["path_date"]
+        elif pd.notnull(row["exif_date"]):
+            row["date"] = row["exif_date"]
+        else:
+            row["date"] = None
+        return row
+    return df.apply(f, axis=1)
+
+def arrange_columns(df):
+    metadata_cols = [
+        "path", "station", "check", "camera",
+        "date", "path_date", "exif_date", "exif_time",
+        "coordinates_long", "coordinates_lat", "exif_gps_long", "exif_gps_lat", "grid_file_long", "grid_file_lat",
+    ]
+    score_cols = [f"{prefix}_{i}" for prefix in ("pred", "score") for i in range(1, N_TOP_RESULTS + 1)]
+    other_cols = [col for col in df.columns if col not in set(metadata_cols + score_cols)]
+    return df[metadata_cols + score_cols + other_cols]
+
+def infer_to_csv(args):
+    if not args.overwrite:
+        assert not Path(args.output).exists(), f"{args.output} already exists, use the 'overwrite' option to proceed anyway."
+    images = get_images(args.input_folder)
+    preds, classes = get_predictions(args.model, images, args.pytorch_num_workers, args.batch_size)
+    df_preds = get_top_preds_and_scores(preds, classes)
+    df_preds["path"] = images
+    df_preds = parse_path(df_preds) # extract station, check, cam where possible from path
+    df_preds = parse_exif(df_preds) # extract datetime, gps_long and gps_lat from exif if images
+    df_preds = add_station_coords(df_preds, args.grid_file)
+    df_preds = add_output_date(df_preds)
+    df_preds = add_output_coords(df_preds)
+    df_preds = arrange_columns(df_preds)
+    df_preds.to_csv(args.output, index=False)
+    print(f"Results stored in {args.output}.")

--- a/models/runner/functions_video.py
+++ b/models/runner/functions_video.py
@@ -1,230 +1,39 @@
-# This script loads all images in subfolders of a specified folder and a model.
-# Next it runs inference from the model on the images and saves a csv with image path, classification, possibly toop predictions and scores.
+# This script extracts image frames from camera trap videos
+# It then copies the images to a new directory (replicating original video dir structure)
+# This new image directory can then be classified
+
 import warnings
 
+import cv2 # might not be needed here if fastai imported first
+
 import os
-from datetime import datetime
 
 from pathlib import Path
 
-import pandas as pd
-
-from fastai import *
-from fastai.vision import *
-
-import exifread
-
 warnings.filterwarnings('ignore')
 
-N_TOP_RESULTS = 3
-
 def is_video(filename):
-    return filename.endswith(("avi", "MP4")) # had a problem with lower() so removed
+    return filename.endswith(("avi", ".mp4", "AVI", "MP4"))
 
-def get_videos(data_folder):
+def get_videos(video_data_folder):
     videos = []
     try:
-        for dirpath, dirnames, filenames in os.walk(data_folder):
+        for dirpath, dirnames, filenames in os.walk(video_data_folder):
             for filename in [f for f in filenames if is_video(f)]:
                 videos.append(os.path.join(dirpath, filename))
     except Exception as e:
-        print(f"Got exception {e}, double check {data_folder} is a folder")
+        print(f"Got exception {e}, double check {video_data_folder} is a folder")
     assert videos, "No videos found in the folder"
     print(f"Found {len(videos)} videos.")
     return videos
 
-# Re-create directory structure in new image folder
-# TO DO
+def copy_dir_tree(video_data_folder, new_image_data_folder):
+    for dirpath, dirnames, filenames in os.walk(video_data_folder):
+        structure = os.path.join(new_image_data_folder, os.path.relpath(dirpath, video_data_folder))
+        if not os.path.isdir(structure):
+            os.mkdir(structure)
 
-# Extract video frames and output to new image directories
-def extract_frames(video):
-    index = 0
-    while(True):
-        # Extract images
-        video.set(cv2.CAP_PROP_POS_MSEC,(index*15000)) # frame every 15 seconds
-        ret, frame = video.read()
-        # end of frames
-        if not ret: 
-            break
-    # Saves images
-    name = IMAGEDIR + VIDNAME + '_' + f"{index+1:02d}" + '.jpg'
-    print ('Creating...' + name)
-    cv2.imwrite(name, frame)
-
-    # next frame
-    index += 1
-
-
-def load_model(model, images, pytorch_num_workers, batch_size):
-    model_path = Path(model)
-    print(f"Loading model: {model}.")
-    assert model_path.exists(), f"It seems {model} is not a file"
-    assert model_path.suffix == ".pkl", "The model should end with .pkl"
-    learn = load_learner(model_path.parent, model_path.name, test=images, num_workers=pytorch_num_workers)
-    learn.data.batch_size = batch_size
-    # learn.callback_fns=[]
-    print(f"Model loaded.")
-    return learn
-
-def get_gpu_status(learn):
-    if torch.cuda.device_count() > 0:
-        print("GPU available.")
-        try:
-            learn.model = model.cuda()
-            print("Using GPU for inference.")
-        except:
-            print("Unable to use GPU, using CPU.")
-    else:
-        print("No GPU detected.")
-
-def run_inference(learn):
-    inference_start = datetime.now()
-    print(f"Starting inference. time={inference_start}")
-    preds,y = learn.get_preds(ds_type=DatasetType.Test)
-    inference_stop = datetime.now()
-    print(f"Inference complete. It took {inference_stop - inference_start}.")
-    return preds
-
-def get_predictions(model, images, pytorch_num_workers, batch_size):
-    learn = load_model(model, images, pytorch_num_workers, batch_size)
-    get_gpu_status(learn)
-    preds = run_inference(learn)
-    classes = learn.data.classes
-    preds = pd.DataFrame(
-            np.stack(preds),
-            columns=classes,
-        )
-    return preds, classes
-
-def get_top_preds_and_scores(preds, classes):
-    df_preds = preds.copy()
-    ranks = df_preds.rank(axis=1,method='dense', ascending=False).astype(int)
-
-    for i in range(1, N_TOP_RESULTS + 1):
-        df_preds[f"pred_{i}"] = pd.Series(ranks.where(ranks==i).notnull().values.nonzero()[1]).apply(lambda x: classes[x])
-        df_preds[f"score_{i}"] = df_preds.apply(lambda x: x[x[f"pred_{i}"]], axis=1)
-
-    return df_preds
-
-def parse_path(df):
-    """ extract station, check and cam from path column and store. """
-    pattern = r"Check\s(\d*).*STATION_(\d*).*CAM(\d*).*[\\/](\d{6})[\\/]"
-    result = df.copy()
-    result[["check", "station", "camera", "path_date"]] = result.path.str.extract(pattern)
-    result["station"] = pd.to_numeric(result["station"])
-    result["path_date"] = pd.to_datetime(result["path_date"], format="%m%d%y").map(lambda x: x.date())
-    return result
-
-def read_exif_coords(tags):
-    """Read GPS coordinates from Exif tags and return longitude, latitude tuple"""
-    def get_coord(ref, coord):
-        ref = {"N": 1, "S": -1, "W": -1, "E": 1}[ref.values]
-        degrees, minutes, seconds = (v.num / v.den for v in coord.values)
-        return ref * (degrees + minutes / 60 + seconds / 3600)
-
-    try:
-        long = get_coord(tags["GPS GPSLongitudeRef"], tags["GPS GPSLongitude"])
-        lat = get_coord(tags["GPS GPSLatitudeRef"], tags["GPS GPSLatitude"])
-        return long, lat
-    except KeyError:
-        return None, None
-
-def parse_exif(df):
-    """ extract datetime, gps long and gps lat from exif of images """
-    result = df.copy()
-
-    exif_datetime = []
-    exif_gps_long = []
-    exif_gps_lat = []
-    for path_name in result.path:
-        f = open(path_name, 'rb')
-        tags = exifread.process_file(f)
-        if tags:
-            try:
-                exif_datetime.append(tags["EXIF DateTimeOriginal"].values)
-            except KeyError:
-                exif_datetime.append(None)
-            long, lat = read_exif_coords(tags)
-            exif_gps_long.append(long)
-            exif_gps_lat.append(lat)
-        else:
-            exif_datetime.append(None)
-            exif_gps_long.append(None)
-            exif_gps_lat.append(None)
-    exif_datetime = pd.to_datetime(exif_datetime, format="%Y:%m:%d %H:%M:%S")
-    result["exif_date"] = exif_datetime.map(lambda x: x.date())
-    result["exif_time"] = exif_datetime.map(lambda x: x.time())
-    result["exif_gps_long"] = exif_gps_long
-    result["exif_gps_lat"] = exif_gps_lat
-
-    return result
-
-def add_station_coords(df, grid_file):
-    """Add station coordinates matched from the grid file"""
-    # Grid file column name --> output column name mapping.
-    columns = {
-        "locationID": "station",
-        "Longitude": "grid_file_long",
-        "Latitude": "grid_file_lat",
-    }
-    if grid_file is None:
-        # Use empty data frame - as if the grid file had no stations.
-        stations = pd.DataFrame(columns=columns.values())
-    else:
-        stations = pd.read_csv(grid_file)
-        stations.rename(columns=columns, inplace=True, errors="raise")
-    return pd.merge(df, stations, how="left", on="station")
-
-def add_output_coords(df):
-    """Add output coordinates determined on best-effort basis"""
-    def f(row):
-        # Prefer Exif.
-        if pd.notnull(row["exif_gps_long"]) and pd.notnull(row["exif_gps_lat"]):
-            long, lat = row["exif_gps_long"], row["exif_gps_lat"]
-        elif pd.notnull(row["grid_file_long"]) and pd.notnull(row["grid_file_lat"]):
-            long, lat = row["grid_file_long"], row["grid_file_lat"]
-        else:
-            long, lat = None, None
-        row["coordinates_long"] = long
-        row["coordinates_lat"] = lat
-        return row
-    return df.apply(f, axis=1)
-
-def add_output_date(df):
-    """Add output date determined on best-effort basis"""
-    def f(row):
-        # Prefer date extracted from path.
-        if pd.notnull(row["path_date"]):
-            row["date"] = row["path_date"]
-        elif pd.notnull(row["exif_date"]):
-            row["date"] = row["exif_date"]
-        else:
-            row["date"] = None
-        return row
-    return df.apply(f, axis=1)
-
-def arrange_columns(df):
-    metadata_cols = [
-        "path", "station", "check", "camera",
-        "date", "path_date", "exif_date", "exif_time",
-        "coordinates_long", "coordinates_lat", "exif_gps_long", "exif_gps_lat", "grid_file_long", "grid_file_lat",
-    ]
-    score_cols = [f"{prefix}_{i}" for prefix in ("pred", "score") for i in range(1, N_TOP_RESULTS + 1)]
-    other_cols = [col for col in df.columns if col not in set(metadata_cols + score_cols)]
-    return df[metadata_cols + score_cols + other_cols]
-
-def infer_to_csv(args):
-    if not args.overwrite:
-        assert not Path(args.output).exists(), f"{args.output} already exists, use the 'overwrite' option to proceed anyway."
-    images = get_images(args.input_folder)
-    preds, classes = get_predictions(args.model, images, args.pytorch_num_workers, args.batch_size)
-    df_preds = get_top_preds_and_scores(preds, classes)
-    df_preds["path"] = images
-    df_preds = parse_path(df_preds) # extract station, check, cam where possible from path
-    df_preds = parse_exif(df_preds) # extract datetime, gps_long and gps_lat from exif if images
-    df_preds = add_station_coords(df_preds, args.grid_file)
-    df_preds = add_output_date(df_preds)
-    df_preds = add_output_coords(df_preds)
-    df_preds = arrange_columns(df_preds)
-    df_preds.to_csv(args.output, index=False)
-    print(f"Results stored in {args.output}.")
+def get_filename(path):
+    head, tail = os.path.split(path)
+    return tail or os.path.basename(head)
+    


### PR DESCRIPTION
Apologies this might have been better as a feature request but I've made a lot of progress so it might be relatively easy to integrate. The motivation for creating it is that two large projects/organisations are very interested in the app but all of their data are in video format. Also, many organisations are keen to use video for various reasons, so video support will greatly expand the number of users who are likely to use the app.

Having thought about this a lot, the simplest way to allow users to classify videos is have them choose the folder/s with the videos and the app then automatically extracts images from the video clips and save* the images in a new directory (with the same original directory structure to preserver camera station information etc). The user can then select the new image directory and the classifier can be run in the usual way.

The PR has two python scripts:

1.functions_video.py provides functions that extract paths from a folder of video files (avi, mp4) and then re-creates the video folder's directory structure.

2. extract_frames.py is a working demo script (just provide an input video directory and an empty directory for the extracted images). The script extracts image frames from all of the videos (5 s intervals) into the new image directory with appropriate filenames and the correct directory structure. Once this is completed the user can classify the image folder as normal.

This would be a major boost to functionality. Here is a link to one of the projects that are interested, they have been trying to analyse this data for years: https://www.zooniverse.org/projects/sassydumbledore/chimp-and-see/classify




