### PR TITLE
Log errors to classifier output instead of a toast.

### DIFF
--- a/app/components/Classifier.tsx
+++ b/app/components/Classifier.tsx
@@ -136,7 +136,7 @@ const computePredictions = (
     process.stderr.on('data', data => {
       // eslint-disable-next-line no-console
       console.log(`classifier stderr: ${data}`);
-      displayErrorToast(`${data}`);
+      changeLogMessage(`${data}`);
     });
     process.on('exit', exitCode => {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Closes #114 
