### PR TITLE
Fix: Missing relative position on explore page.

### DIFF
--- a/app/containers/ExplorePage.tsx
+++ b/app/containers/ExplorePage.tsx
@@ -153,7 +153,8 @@ export default function ExplorePage() {
           overflowY: 'scroll',
           maxHeight: 'calc(100vh - 50px)',
           display: 'flex',
-          flexDirection: 'column'
+          flexDirection: 'column',
+          position: 'relative'
         }}
       >
         <Card


### PR DESCRIPTION
- Fixed absolute positioning for load data in explore page.

![Peek 2020-09-07 14-36](https://user-images.githubusercontent.com/44022548/92388761-16aa7380-f118-11ea-9eba-1d19c7a71cb0.gif)

